### PR TITLE
Add secrets to task definition

### DIFF
--- a/src/ecs_deplojo/task_definitions.py
+++ b/src/ecs_deplojo/task_definitions.py
@@ -31,6 +31,13 @@ class TaskDefinition:
                 ],
                 key=operator.itemgetter("name"),
             )
+            container["secrets"] = sorted(
+                [
+                    {"name": k, "valueFrom": str(v)}
+                    for k, v in container.get("secrets", {}).items()
+                ],
+                key=operator.itemgetter("name"),
+            )
         return result
 
     def apply_variables(self, variables: typing.Dict[str, str]):
@@ -54,6 +61,16 @@ class TaskDefinition:
         """Interpolate all the variables used in the task definition"""
         for container in self.container_definitions:
             container["environment"] = env
+
+    def set_secrets(self, secrets: typing.Dict[str, str]):
+        """Interpolate all the secrets used in the task definition.
+
+        Secrets will be fetched from the AWS Parameter store and injected in the
+        environment variables during container startup
+
+        """
+        for container in self.container_definitions:
+            container["secrets"] = secrets
 
     def __str__(self):
         if self._data.get("name"):
@@ -158,11 +175,12 @@ def generate_task_definitions(
             name=name,
             base_path=base_path,
             task_role_arn=info.get("task_role_arn"),
+            secrets=config.get("secrets", {}),
         )
-
         if output_path:
             write_task_definition(name, definition, output_path)
         task_definitions[name] = definition
+
     return task_definitions
 
 
@@ -174,6 +192,7 @@ def generate_task_definition(
     name,
     base_path=None,
     task_role_arn=None,
+    secrets: typing.Dict[str, str] = {},
 ) -> TaskDefinition:
 
     """Generate the task definitions"""
@@ -197,6 +216,8 @@ def generate_task_definition(
         container.setdefault("hostname", hostname)
 
     task_definition.set_environment(environment)
+    if secrets:
+        task_definition.set_secrets(secrets)
     task_definition.apply_variables(template_vars)
     task_definition.apply_overrides(overrides)
     task_definition.tags = [{"key": "createdBy", "value": "ecs-deplojo"}]

--- a/tests/test_task_definitions.py
+++ b/tests/test_task_definitions.py
@@ -392,3 +392,71 @@ def test_generate_task_definition_with_task_role_arn(tmpdir):
         }
     )
     assert result == expected
+
+
+def test_generate_task_definition_with_secrets(tmpdir):
+    task_data = """
+    {
+      "family": "default",
+      "volumes": [],
+      "containerDefinitions": [
+        {
+          "name": "default",
+          "image": "${image}",
+          "essential": true,
+          "command": ["hello", "world"],
+          "memory": 256,
+          "cpu": 0,
+          "portMappings": [
+            {
+              "containerPort": 8080,
+              "hostPort": 0
+            }
+          ]
+        }
+      ]
+    }
+    """.strip()
+
+    filename = tmpdir.join("task_definition.json")
+    filename.write(task_data)
+
+    result = task_definitions.generate_task_definition(
+        filename.strpath,
+        environment={},
+        task_role_arn="arn:my-task-role",
+        template_vars={"image": "my-docker-image:1.0"},
+        overrides={},
+        name="my-task-def",
+        secrets={
+          "SUPER_SECRET_ENV_VAR": "/path/in/param/store",
+          "SUPER_SECRET_ENV_VAR2": "/other/path/in/param/store",
+        }
+    )
+
+    expected = task_definitions.TaskDefinition(
+        {
+            "family": "my-task-def",
+            "taskRoleArn": "arn:my-task-role",
+            "volumes": [],
+            "containerDefinitions": [
+                {
+                    "name": "default",
+                    "image": "my-docker-image:1.0",
+                    "essential": True,
+                    "hostname": "my-task-def",
+                    "command": ["hello", "world"],
+                    "memory": 256,
+                    "cpu": 0,
+                    "portMappings": [{"containerPort": 8080, "hostPort": 0}],
+                    "environment": {},
+                    "secrets": {
+                      "SUPER_SECRET_ENV_VAR": "/path/in/param/store",
+                      "SUPER_SECRET_ENV_VAR2": "/other/path/in/param/store",
+                    }
+                }
+            ],
+            "tags": [{"key": "createdBy", "value": "ecs-deplojo"}],
+        }
+    )
+    assert result == expected


### PR DESCRIPTION
Secrets are in the form of /path/to/paremeter which is an parameter in the AWS Parameter Store