### PR TITLE
update boto3 requirement to range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    'boto3==1.10.23',
+    'boto3>=1.10.39,<1.11.0',
     'click==7.0',
     'pyaml==16.12.2',
     'pytz',


### PR DESCRIPTION
boto3 had update for ecs in 1.10.31. We now take latest stable release (1.10.39) and allow patch updates of boto3.