### PR TITLE
Feature/skip hostnames for awsvpc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,14 @@ When the container is started the secrets are available as environment variables
 hidden in the AWS ECS console.
 
 
+AWS Fargate
+-----------
+
+Services within AWS Fargate run in a AWS default vpc and therfore don't support the
+hostname config for containers. When you define ``networkMode="awsvpc"`` the hostname
+will not be included when creating a task definition.
+
+
 Example log output
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -120,12 +120,19 @@ When the container is started the secrets are available as environment variables
 hidden in the AWS ECS console.
 
 
+AWS Default VPC
+---------------
+
+When running your servers in the AWS default VPC you need ``networkMode="awsvpc"`` in
+your task definition JSON file, this will ensure that no hostnames are set for the
+containers, since this isn't supported by AWS.
+
+
 AWS Fargate
 -----------
 
-Services within AWS Fargate run in a AWS default vpc and therfore don't support the
-hostname config for containers. When you define ``networkMode="awsvpc"`` the hostname
-will not be included when creating a task definition.
+Unlike EC2 based clusters AWS Fargate needs a ``execution_role_arn`` to work, this can be
+set in your service definition in the YAML file.
 
 
 Example log output

--- a/src/ecs_deplojo/task_definitions.py
+++ b/src/ecs_deplojo/task_definitions.py
@@ -193,7 +193,6 @@ def generate_task_definitions(
             task_role_arn=info.get("task_role_arn"),
             secrets=config.get("secrets", {}),
             execution_role_arn=info.get("execution_role_arn"),
-            network_mode=config.get("network_mode")
         )
         if output_path:
             write_task_definition(name, definition, output_path)
@@ -212,10 +211,8 @@ def generate_task_definition(
     task_role_arn=None,
     secrets: typing.Dict[str, str] = {},
     execution_role_arn=None,
-    network_mode=None,
 ) -> TaskDefinition:
-
-    """Generate the task definitions"""
+    """Generate the task definitions."""
     if base_path:
         filename = os.path.join(base_path, filename)
 
@@ -232,7 +229,7 @@ def generate_task_definition(
     # If no hostname is specified for the container we set it ourselves to
     # `{family}-{container-name}-{num}`
     # Skip this when network_mode == awsvpc, not supported by AWS.
-    if network_mode not in ["awsvpc"]:
+    if task_definition.network_mode not in ["awsvpc"]:
         num_containers = len(task_definition.container_definitions)
         for container in task_definition.container_definitions:
             hostname = task_definition.family

--- a/tests/test_task_definitions.py
+++ b/tests/test_task_definitions.py
@@ -556,7 +556,6 @@ def test_generate_task_definition_awsvpc(tmpdir):
         template_vars={"image": "my-docker-image:1.0"},
         overrides={},
         name="my-task-def",
-        network_mode="awsvpc"
     )
     expected = task_definitions.TaskDefinition(
         {

--- a/tests/test_task_definitions.py
+++ b/tests/test_task_definitions.py
@@ -520,3 +520,62 @@ def test_generate_task_definition_with_secrets(tmpdir):
         }
     )
     assert result == expected
+
+
+def test_generate_task_definition_awsvpc(tmpdir):
+    task_data = """
+    {
+      "family": "default",
+      "networkMode": "awsvpc",
+      "volumes": [],
+      "containerDefinitions": [
+        {
+          "name": "default",
+          "image": "${image}",
+          "essential": true,
+          "command": ["hello", "world"],
+          "memory": 256,
+          "cpu": 0,
+          "portMappings": [
+            {
+              "containerPort": 8080,
+              "hostPort": 0
+            }
+          ]
+        }
+      ]
+    }
+    """.strip()
+
+    filename = tmpdir.join("task_definition.json")
+    filename.write(task_data)
+
+    task_definition = task_definitions.generate_task_definition(
+        filename.strpath,
+        environment={},
+        template_vars={"image": "my-docker-image:1.0"},
+        overrides={},
+        name="my-task-def",
+        network_mode="awsvpc"
+    )
+    expected = task_definitions.TaskDefinition(
+        {
+            "family": "my-task-def",
+            "volumes": [],
+            "networkMode": "awsvpc",
+            "containerDefinitions": [
+                {
+                    "name": "default",
+                    "image": "my-docker-image:1.0",
+                    "essential": True,
+                    "command": ["hello", "world"],
+                    "memory": 256,
+                    "cpu": 0,
+                    "portMappings": [{"containerPort": 8080, "hostPort": 0}],
+                    "environment": {},
+                }
+            ],
+            "tags": [{"key": "createdBy", "value": "ecs-deplojo"}],
+        }
+    )
+    assert task_definition == expected


### PR DESCRIPTION
Skip hostname in container definitions when the task definition has ``networkMode="awsvpc"``.


Fixes: #26 